### PR TITLE
Add CSS class values for property groups and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 	</li>
 </ul>
 <h2 id="introduction">Introduction</h2>
-<p>This API provides access to detailed information for all characters, blocks and planes in <a href="https://www.unicode.org/versions/Unicode15.1.0/" rel="noopener noreferrer" target="_blank">version 15.1.0 of the Unicode Standard</a> (released Sep 12, 2023). In an attempt to adhere to the tenants of <a href="http://en.wikipedia.org/wiki/Representational_State_Transfer" rel="noopener noreferrer" target="_blank">REST</a>, the API is organized around the following principles:</p>
+<p>This API provides access to detailed information for all characters, blocks and planes in <a href="https://www.unicode.org/versions/Unicode15.0.0/" rel="noopener noreferrer" target="_blank">version 15.0.0 of the Unicode Standard</a> (released Sep 13, 2022). In an attempt to adhere to the tenants of <a href="http://en.wikipedia.org/wiki/Representational_State_Transfer" rel="noopener noreferrer" target="_blank">REST</a>, the API is organized around the following principles:</p>
 <ul class="api-principles">
     <li>URLs are predictable and resource-oriented.</li>
     <li>Uses standard HTTP verbs and response codes.</li>
@@ -147,7 +147,7 @@
     <p>The <code>UnicodeCharacter</code> object represents a single character/codepoint in the <a href="https://unicode.org/reports/tr44/" rel="noopener noreferrer" target="_blank">Unicode Character Database (UCD)</a>. It contains a rich set of properties that document the purpose and intended representation of the character.</p>
     <h4 id="unicodecharacter-property-groups"><code>UnicodeCharacter</code> Property Groups</h4>
     <p>If each response contained every character property, it would be massively inneficient. To ensure that the API remains responsive and performant while also allowing clients to access the full set of character properties, each property is assigned to a <strong>property group</strong>.</p><p>Since they are designed to return lists of characters, responses from the <code>/v1/characters</code> or <code>/v1/characters/search</code> endpoints will only include properties from the <strong>Minimum</strong> property group:</p>
-	<details class=True>
+	<details open class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -186,7 +186,7 @@
 	<p>If you wish to explore the properties of one or more specifc characters, the <code>/v1/characters/-/{string}</code> and <code>/v1/characters/filter</code> endpoints accept one or more <code>show_props</code> parameters that allow you to specify additional property groups to include in the response.</p><p>For example, you could view the properties from groups <strong>UTF-8</strong>, <strong>Numeric</strong>, and <strong>Script</strong> for the character Ⱒ (<code>U+2C22 <span>GLAGOLITIC CAPITAL LETTER SPIDERY HA</span></code>), which is equal to <code>0xE2 0xB0 0xA2</code> in UTF-8 encoding by submitting the following request: <a href="http://localhost:3507/v1/characters/%E2%B0%A2?show_props=UTF8&show_props=Numeric&show_props=Script" rel="noopener noreferrer" target="_blank">/v1/characters/%E2%B0%A2?show_props=UTF8&show_props=Numeric&show_props=Script</a>.</p>
 	<h4 id="verbosity">Verbosity</h4>
 	<p>The value of many of the properties that are defined for each character are only meaningful for specific blocks or a small subset of codepoints (e.g., the <code>hangul_syllable_type</code> property will have a <code>(Not Applicable) NA</code> value for all codepoints except those in the four blocks that contain characters from the Hangul writing system).</p><p>By default, the <code>hangul_syllable_type</code> property will <strong>NOT</strong> be included with the response for any character that has this default value even if the user has submitted a request containing <code>show_props=hangul</code> or <code>show_props=all</code>. For actual Hangul characters, the property will be included in the response.</p><p>These properties are removed to make the size of each response as small as possible. Knowing that the 🇺 (<code>U+1F1FA <span>REGIONAL INDICATOR SYMBOL LETTER U</span></code>) character has the value <code>hangul_syllable_type=NA</code> provides no real information about this character.</p><p>However, if you wish to see every property value, include <code>verbose=true</code> with your request to the <code>/v1/characters/-/{string}</code> or <code>/v1/characters/filter</code> endpoints.</p>
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -227,7 +227,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -249,7 +249,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -271,7 +271,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -293,7 +293,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -337,7 +337,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -377,7 +377,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -419,7 +419,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -454,7 +454,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -487,7 +487,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -545,7 +545,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -573,7 +573,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -600,7 +600,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -623,7 +623,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -650,7 +650,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -671,7 +671,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -709,7 +709,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -744,7 +744,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -782,7 +782,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -838,7 +838,7 @@
         </dl>
 	</details>
 	<br />
-	<details>
+	<details class='property-group'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -888,7 +888,7 @@
 </div>
 <h3 id="unicode-blocks">Unicode Blocks</h3>
 <div>
-	<details class=True>
+	<details open class='api-endpoints'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">
@@ -941,7 +941,7 @@
 </div>
 <h3 id="unicode-planes">Unicode Planes</h3>
 <div>
-	<details class=True>
+	<details open class='api-endpoints'>
         <summary style="list-style: none; align-items: center">
             <div style="display: flex; gap: 0.75rem; align-items: center; justify-content: space-between; flex: 0; margin: 0 0 0 0.25rem; padding: 0.25rem 1rem 0.25rem 0">
                 <div style="height: 16px; transition: transform 0.3s ease-in">

--- a/app/data/scripts/get_prod_data.py
+++ b/app/data/scripts/get_prod_data.py
@@ -11,67 +11,67 @@ def get_prod_data() -> Result[None]:
     result = bootstrap_unicode_data()
     if result.failure or not result.value:
         return Result.Fail(result.error if result.error else "")
-    config = result.value
+    settings = result.value
 
-    result = get_unicode_db(config)
+    result = get_unicode_db(settings)
     if result.failure:
         return result
 
-    result = get_unicode_json(config)
+    result = get_unicode_json(settings)
     if result.failure:
         return result
     return Result.Ok()
 
 
-def get_unicode_db(config: UnicodeApiSettings) -> Result[None]:
-    result = download_file(config.DB_ZIP_URL, config.DB_FOLDER)
+def get_unicode_db(settings: UnicodeApiSettings) -> Result[None]:
+    result = download_file(settings.DB_ZIP_URL, settings.DB_FOLDER)
     if result.failure:
         return Result.Fail(result.error if result.error else "")
-    if not config.DB_ZIP_FILE.exists():
-        return Result.Fail(f"Failed to download {config.DB_ZIP_FILE.name}")
+    if not settings.DB_ZIP_FILE.exists():
+        return Result.Fail(f"Failed to download {settings.DB_ZIP_FILE.name}")
 
-    result = extract_unicode_db(config)
+    result = extract_unicode_db(settings)
     if result.failure:
         return Result.Fail(result.error if result.error else "")
-    config.DB_ZIP_FILE.unlink()
+    settings.DB_ZIP_FILE.unlink()
     return Result.Ok()
 
 
-def extract_unicode_db(config: UnicodeApiSettings) -> Result[list[Path]]:
-    with ZipFile(config.DB_ZIP_FILE, mode="r") as zip:
-        zip.extractall(path=str(config.DB_FOLDER))
-        extracted_files = list(config.DB_FOLDER.glob("*.db"))
+def extract_unicode_db(settings: UnicodeApiSettings) -> Result[list[Path]]:
+    with ZipFile(settings.DB_ZIP_FILE, mode="r") as zip:
+        zip.extractall(path=str(settings.DB_FOLDER))
+        extracted_files = list(settings.DB_FOLDER.glob("*.db"))
         if not extracted_files:
-            return Result.Fail(f"Error occurred extracting Unicode DB from {config.DB_ZIP_FILE.name}!")
+            return Result.Fail(f"Error occurred extracting Unicode DB from {settings.DB_ZIP_FILE.name}!")
         if len(extracted_files) != 1:
-            error = f"{len(extracted_files)} files were extracted from {config.DB_ZIP_FILE.name}, expected 1:\n"
+            error = f"{len(extracted_files)} files were extracted from {settings.DB_ZIP_FILE.name}, expected 1:\n"
             for i, file in enumerate(extracted_files, start=1):
                 error += f"\tFile #{i}: {file.name}"
             return Result.Fail(error)
         return Result.Ok(extracted_files)
 
 
-def get_unicode_json(config: UnicodeApiSettings) -> Result[None]:
-    result = download_file(config.JSON_ZIP_URL, config.JSON_FOLDER)
+def get_unicode_json(settings: UnicodeApiSettings) -> Result[None]:
+    result = download_file(settings.JSON_ZIP_URL, settings.JSON_FOLDER)
     if result.failure:
         return Result.Fail(result.error if result.error else "")
-    if not config.JSON_ZIP_FILE.exists():
-        return Result.Fail(f"Failed to download {config.JSON_ZIP_FILE.name}")
-    result = extract_unicode_json(config)
+    if not settings.JSON_ZIP_FILE.exists():
+        return Result.Fail(f"Failed to download {settings.JSON_ZIP_FILE.name}")
+    result = extract_unicode_json(settings)
     if result.failure:
         return Result.Fail(result.error if result.error else "")
-    config.JSON_ZIP_FILE.unlink()
+    settings.JSON_ZIP_FILE.unlink()
     return Result.Ok()
 
 
-def extract_unicode_json(config: UnicodeApiSettings) -> Result[list[Path]]:
-    with ZipFile(config.JSON_ZIP_FILE, mode="r") as zip:
-        zip.extractall(path=str(config.JSON_FOLDER))
-        extracted_files = list(config.JSON_FOLDER.glob("*.json"))
+def extract_unicode_json(settings: UnicodeApiSettings) -> Result[list[Path]]:
+    with ZipFile(settings.JSON_ZIP_FILE, mode="r") as zip:
+        zip.extractall(path=str(settings.JSON_FOLDER))
+        extracted_files = list(settings.JSON_FOLDER.glob("*.json"))
         if not extracted_files:
-            return Result.Fail(f"Error occurred extracting Unicode DB from {config.JSON_ZIP_FILE.name}!")
+            return Result.Fail(f"Error occurred extracting Unicode DB from {settings.JSON_ZIP_FILE.name}!")
         if len(extracted_files) != 3:
-            error = f"{len(extracted_files)} files were extracted from {config.JSON_ZIP_FILE.name}, expected 3:\n"
+            error = f"{len(extracted_files)} files were extracted from {settings.JSON_ZIP_FILE.name}, expected 3:\n"
             for i, file in enumerate(extracted_files, start=1):
                 error += f"\tFile #{i}: {file.name}"
             return Result.Fail(error)

--- a/app/docs/api_docs/readme.py
+++ b/app/docs/api_docs/readme.py
@@ -97,8 +97,93 @@ def create_details_element_for_api_endpoints(id: str, content: str, open: bool |
     return create_details_element_readme(title=title, content=content, class_name="api-endpoints", open=open)
 
 
+def create_details_element_for_property_group(prop_group: str, content: str, open: bool | None = False) -> str:
+    title = f"<strong>{prop_group}</strong>"
+    return create_details_element_readme(title=title, content=content, class_name="property-group", open=open)
+
+
+# API ENDPOINT DETAILS ELEMENTS
+CHARACTER_API_ENDPOINTS = create_details_element_for_api_endpoints(
+    id="character-api-endpoints", content=CHARACTER_ENDPOINTS, open=True
+)
+CODEPOINT_API_ENDPOINTS = create_details_element_for_api_endpoints(
+    id="codepoint-api-endpoints", content=CODEPOINTS_ENDPOINTS, open=True
+)
+BLOCK_API_ENDPOINTS = create_details_element_for_api_endpoints(
+    id="block-api-endpoints", content=BLOCK_ENDPOINTS, open=True
+)
+PLANE_API_ENDPOINTS = create_details_element_for_api_endpoints(
+    id="plane-api-endpoints", content=PLANE_ENDPOINTS, open=True
+)
+
+# CHARACTER PROPERTY GROUP DETAILS ELEMENTS
+CHARACTER_PROP_GROUP_MINIMUM = create_details_element_for_property_group(
+    prop_group="Minimum", content=PROP_GROUP_MINIMUM, open=True
+)
+CHARACTER_PROP_GROUP_BASIC = create_details_element_for_property_group(
+    prop_group="Basic", content=PROP_GROUP_BASIC, open=False
+)
+CHARACTER_PROP_GROUP_UTF8 = create_details_element_for_property_group(
+    prop_group="UTF-8", content=PROP_GROUP_UTF8, open=False
+)
+CHARACTER_PROP_GROUP_UTF16 = create_details_element_for_property_group(
+    prop_group="UTF-16", content=PROP_GROUP_UTF16, open=False
+)
+CHARACTER_PROP_GROUP_UTF32 = create_details_element_for_property_group(
+    prop_group="UTF-32", content=PROP_GROUP_UTF32, open=False
+)
+CHARACTER_PROP_GROUP_BIDIRECTIONALITY = create_details_element_for_property_group(
+    prop_group="Bidirectionality", content=PROP_GROUP_BIDIRECTIONALITY, open=False
+)
+CHARACTER_PROP_GROUP_DECOMPOSITION = create_details_element_for_property_group(
+    prop_group="Decomposition", content=PROP_GROUP_DECOMPOSITION, open=False
+)
+CHARACTER_PROP_GROUP_QUICK_CHECK = create_details_element_for_property_group(
+    prop_group="Quick Check", content=PROP_GROUP_QUICK_CHECK, open=False
+)
+CHARACTER_PROP_GROUP_NUMERIC = create_details_element_for_property_group(
+    prop_group="Numeric", content=PROP_GROUP_NUMERIC, open=False
+)
+CHARACTER_PROP_GROUP_JOINING = create_details_element_for_property_group(
+    prop_group="Joining", content=PROP_GROUP_JOINING, open=False
+)
+CHARACTER_PROP_GROUP_LINEBREAK = create_details_element_for_property_group(
+    prop_group="Linebreak", content=PROP_GROUP_LINEBREAK, open=False
+)
+CHARACTER_PROP_GROUP_EAW = create_details_element_for_property_group(
+    prop_group="East Asian Width", content=PROP_GROUP_EAW, open=False
+)
+CHARACTER_PROP_GROUP_CASE = create_details_element_for_property_group(
+    prop_group="Case", content=PROP_GROUP_CASE, open=False
+)
+CHARACTER_PROP_GROUP_SCRIPT = create_details_element_for_property_group(
+    prop_group="Script", content=PROP_GROUP_SCRIPT, open=False
+)
+CHARACTER_PROP_GROUP_HANGUL = create_details_element_for_property_group(
+    prop_group="Hangul", content=PROP_GROUP_HANGUL, open=False
+)
+CHARACTER_PROP_GROUP_INDIC = create_details_element_for_property_group(
+    prop_group="Indic", content=PROP_GROUP_INDIC, open=False
+)
+CHARACTER_PROP_GROUP_CJK_VARIANTS = create_details_element_for_property_group(
+    prop_group="CJK Variants", content=PROP_GROUP_CJK_VARIANTS, open=False
+)
+CHARACTER_PROP_GROUP_CJK_NUMERIC = create_details_element_for_property_group(
+    prop_group="CJK Numeric", content=PROP_GROUP_CJK_NUMERIC, open=False
+)
+CHARACTER_PROP_GROUP_CJK_READINGS = create_details_element_for_property_group(
+    prop_group="CJK Readings", content=PROP_GROUP_CJK_READINGS, open=False
+)
+CHARACTER_PROP_GROUP_F_AND_G = create_details_element_for_property_group(
+    prop_group="Function and Graphic", content=PROP_GROUP_F_AND_G, open=False
+)
+CHARACTER_PROP_GROUP_EMOJI = create_details_element_for_property_group(
+    prop_group="Emoji", content=PROP_GROUP_EMOJI, open=False
+)
+
+
 UNICODE_CHARACTER_PROP_GROUPS_README = (
-    f'{create_details_element_readme("<strong>Minimum</strong>", PROP_GROUP_MINIMUM, True)}'
+    f"{CHARACTER_PROP_GROUP_MINIMUM}"
     + "\t<br />\n"
     + "\t"
     + CHARACTER_PROP_GROUPS_CONTINUED_1
@@ -106,51 +191,48 @@ UNICODE_CHARACTER_PROP_GROUPS_README = (
     + CHARACTER_PROP_GROUPS_CONTINUED_2
     + '\n\t<h4 id="verbosity">Verbosity</h4>\n'
     + f"\t{VERBOSITY}\n"
-    + f'{create_details_element_readme("<strong>Basic</strong>", PROP_GROUP_BASIC)}'
+    + f"{CHARACTER_PROP_GROUP_BASIC}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>UTF-8</strong>", PROP_GROUP_UTF8)}'
+    + f"{CHARACTER_PROP_GROUP_UTF8}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>UTF-16</strong>", PROP_GROUP_UTF16)}'
+    + f"{CHARACTER_PROP_GROUP_UTF16}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>UTF-32</strong>", PROP_GROUP_UTF32)}'
+    + f"{CHARACTER_PROP_GROUP_UTF32}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Bidirectionality</strong>", PROP_GROUP_BIDIRECTIONALITY)}'
+    + f"{CHARACTER_PROP_GROUP_BIDIRECTIONALITY}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Decomposition</strong>", PROP_GROUP_DECOMPOSITION)}'
+    + f"{CHARACTER_PROP_GROUP_DECOMPOSITION}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Quick Check</strong>", PROP_GROUP_QUICK_CHECK)}'
+    + f"{CHARACTER_PROP_GROUP_QUICK_CHECK}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Numeric</strong>", PROP_GROUP_NUMERIC)}'
+    + f"{CHARACTER_PROP_GROUP_NUMERIC}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Joining</strong>", PROP_GROUP_JOINING)}'
+    + f"{CHARACTER_PROP_GROUP_JOINING}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Linebreak</strong>", PROP_GROUP_LINEBREAK)}'
+    + f"{CHARACTER_PROP_GROUP_LINEBREAK}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>East Asian Width</strong>", PROP_GROUP_EAW)}'
+    + f"{CHARACTER_PROP_GROUP_EAW}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Case</strong>", PROP_GROUP_CASE)}'
+    + f"{CHARACTER_PROP_GROUP_CASE}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Script</strong>", PROP_GROUP_SCRIPT)}'
+    + f"{CHARACTER_PROP_GROUP_SCRIPT}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Hangul</strong>", PROP_GROUP_HANGUL)}'
+    + f"{CHARACTER_PROP_GROUP_HANGUL}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Indic</strong>", PROP_GROUP_INDIC)}'
+    + f"{CHARACTER_PROP_GROUP_INDIC}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>CJK Variants</strong>", PROP_GROUP_CJK_VARIANTS)}'
+    + f"{CHARACTER_PROP_GROUP_CJK_VARIANTS}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>CJK Numeric</strong>", PROP_GROUP_CJK_NUMERIC)}'
+    + f"{CHARACTER_PROP_GROUP_CJK_NUMERIC}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>CJK Readings</strong>", PROP_GROUP_CJK_READINGS)}'
+    + f"{CHARACTER_PROP_GROUP_CJK_READINGS}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Function and Graphic</strong>", PROP_GROUP_F_AND_G)}'
+    + f"{CHARACTER_PROP_GROUP_F_AND_G}"
     + "\t<br />\n"
-    + f'{create_details_element_readme("<strong>Emoji</strong>", PROP_GROUP_EMOJI)}'
+    + f"{CHARACTER_PROP_GROUP_EMOJI}"
 )
 
-CHARACTER_API_ENDPOINTS = create_details_element_for_api_endpoints(
-    id="character-api-endpoints", content=CHARACTER_ENDPOINTS, open=True
-)
-
+# UNICODE CHARACTERS DOCS
 UNICODE_CHARACTERS_DOCS = f"""
 <div>
 {CHARACTER_API_ENDPOINTS}\t<h4 id="the-unicodecharacter-object">The <code>UnicodeCharacter</code> Object</h4>
@@ -160,26 +242,25 @@ UNICODE_CHARACTERS_DOCS = f"""
 {UNICODE_CHARACTER_PROP_GROUPS_README}</div>
 """
 
-CODEPOINTS_API_ENDPOINTS = create_details_element_for_api_endpoints(
-    id="codepoint-api-endpoints", content=CODEPOINTS_ENDPOINTS, open=True
-)
-
+# UNICODE CODEPOINTS DOCS
 UNICODE_CODEPOINTS_DOCS = f"""
 <div>
-{CODEPOINTS_API_ENDPOINTS}\t{CODEPOINT_CONTENT}
+{CODEPOINT_API_ENDPOINTS}\t{CODEPOINT_CONTENT}
 </div>
 """
 
+# UNICODE BLOCKS DOCS
 UNICODE_BLOCKS_DOCS = f"""
 <div>
-{create_details_element_readme('<h4 id="block-api-endpoints">API Endpoints</h4>', BLOCK_ENDPOINTS, True)}\t<h4 id="the-unicodeblock-object">The <code>UnicodeBlock</code> Object</h4>
+{BLOCK_API_ENDPOINTS}\t<h4 id="the-unicodeblock-object">The <code>UnicodeBlock</code> Object</h4>
     {UNICODE_BLOCK_OBJECT_INTRO}
 {create_details_element_readme("<strong><code>UnicodeBlock</code> Properties</strong>", UNICODE_BLOCK_OBJECT_PROPERTIES)}</div>
 """
 
+# UNICODE PLANES DOCS
 UNICODE_PLANES_DOCS = f"""
 <div>
-{create_details_element_readme('<h4 id="plane-api-endpoints">API Endpoints</h4>', PLANE_ENDPOINTS, True)}\t<h4 id="the-unicodeplane-object">The <code>UnicodePlane</code> Object</h4>
+{PLANE_API_ENDPOINTS}\t<h4 id="the-unicodeplane-object">The <code>UnicodePlane</code> Object</h4>
     {UNICODE_PLANE_OBJECT_INTRO}
 {create_details_element_readme("<strong><code>UnicodePlane</code> Properties</strong>", UNICODE_PLANE_OBJECT_PROPERTIES)}</div>
 """

--- a/app/docs/api_docs/swagger_ui.py
+++ b/app/docs/api_docs/swagger_ui.py
@@ -45,6 +45,7 @@ from app.docs.api_docs.content.intro import (
     SEARCH_HTML,
 )
 from app.docs.api_docs.content.plane import PLANE_ENDPOINTS, UNICODE_PLANE_OBJECT_INTRO, UNICODE_PLANE_OBJECT_PROPERTIES
+from app.docs.util import slugify
 
 
 def create_details_element_for_swagger_ui(
@@ -77,11 +78,8 @@ def create_swagger_details_element_with_heading(
 def create_swagger_details_element_for_property_group(
     prop_group: str, heading_level: int, content: str, open: bool | None = False
 ) -> str:
-    id = prop_group.replace("-", "").replace(" ", "-").lower()
-    title = f'<h{heading_level} id="{id}">Property Group: {prop_group}</h{heading_level}>'
-    return create_details_element_for_swagger_ui(
-        title=title, content=content, class_name="unicode-property-group", open=open
-    )
+    title = f'<h{heading_level} id="{slugify(prop_group)}">Property Group: {prop_group}</h{heading_level}>'
+    return create_details_element_for_swagger_ui(title=title, content=content, class_name="property-group", open=open)
 
 
 def create_swagger_details_element_for_api_endpoints(content: str, open: bool | None = False) -> str:


### PR DESCRIPTION
Refactor get_prod_data function to use settings instead of config

Previously, the CSS class values for property groups and API endpoints were missing. This pull request adds the necessary CSS class values to improve the styling of the application.

Additionally, the `get_prod_data` function has been refactored to use settings instead of config, which improves code readability and maintainability.