### PR TITLE
Update Dockerfile and API settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11
+FROM python:3.
+SHELL ["/bin/bash", "-c"]
 
 ARG ENV
 ARG UNICODE_VERSION
@@ -23,6 +24,19 @@ ENV RATE_LIMIT_BURST=${RATE_LIMIT_BURST}
 ENV TEST_HEADER=${TEST_HEADER}
 
 WORKDIR /code
+
+RUN echo $'ENV=${ENV}\n\
+PYTHONPATH=.\n\
+UNICODE_VERSION=${UNICODE_VERSION}\n\
+REDIS_HOST=${REDIS_HOST}\n\
+REDIS_PORT=${REDIS_PORT}\n\
+REDIS_DB=${REDIS_DB}\n\
+REDIS_PW=${REDIS_PW}\n\
+RATE_LIMIT_PER_PERIOD=${RATE_LIMIT_PER_PERIOD}\n\
+RATE_LIMIT_PERIOD_SECONDS=${RATE_LIMIT_PERIOD_SECONDS}\n\
+RATE_LIMIT_BURST=${RATE_LIMIT_BURST}\n\
+TEST_HEADER=${TEST_HEADER}' > /code/.env
+
 RUN pip install -U pip setuptools wheel
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -1,12 +1,12 @@
 import logging
 import os
 
-from app.config.api_settings import UnicodeApiSettings, get_dev_settings, get_prod_settings, get_test_settings
+from app.config.api_settings import UnicodeApiSettings, get_api_settings, get_test_settings
 
 
 def get_settings() -> UnicodeApiSettings:
     env = os.environ.get("ENV", "DEV")
-    settings = get_test_settings() if "TEST" in env else get_prod_settings() if "PROD" in env else get_dev_settings()
+    settings = get_test_settings() if "TEST" in env else get_api_settings()
     logger = logging.getLogger("app.api")
     logger.debug(settings.api_settings_report)
     logger.debug(settings.rate_limit_settings_report)

--- a/app/config/api_settings.py
+++ b/app/config/api_settings.py
@@ -199,7 +199,7 @@ def get_prod_settings() -> UnicodeApiSettings:  # pragma: no cover
     return UnicodeApiSettings(**settings)
 
 
-def get_dev_settings() -> UnicodeApiSettings:  # pragma: no cover
+def get_api_settings() -> UnicodeApiSettings:  # pragma: no cover
     env_vars = read_dotenv_file(DOTENV_FILE)
     settings = {
         "ENV": env_vars.get("ENV", "DEV"),


### PR DESCRIPTION
This commit updates the Dockerfile to use Python 3. and adds a new command to set the shell to "/bin/bash". Additionally, the commit modifies the API settings in the config module to use the new "get_api_settings" function instead of "get_dev_settings".