### PR TITLE
Add new JSON files to backup in update_all_data.py

### DIFF
--- a/app/data/scripts/update_all_data.py
+++ b/app/data/scripts/update_all_data.py
@@ -120,6 +120,8 @@ def backup_json_files(config: UnicodeApiSettings):
         zip.write(config.PLANES_JSON, f"{config.PLANES_JSON.name}")
         zip.write(config.BLOCKS_JSON, f"{config.BLOCKS_JSON.name}")
         zip.write(config.CHAR_NAME_MAP, f"{config.CHAR_NAME_MAP.name}")
+        zip.write(config.UNIHAN_CHARS_JSON, f"{config.UNIHAN_CHARS_JSON.name}")
+        zip.write(config.TANGUT_CHARS_JSON, f"{config.TANGUT_CHARS_JSON.name}")
 
 
 def upload_zip_file_to_s3(config: UnicodeApiSettings, local_file: Path) -> Result[None]:


### PR DESCRIPTION
This pull request adds two new JSON files, `UNIHAN_CHARS_JSON` and `TANGUT_CHARS_JSON`, to the backup process in the `update_all_data.py` script. This ensures that these files are included in the backup when running the script.