### PR TITLE
Fix RATE_LIMIT_ROUTE_REGEX to include 'codepoints'

### DIFF
--- a/app/core/rate_limit.py
+++ b/app/core/rate_limit.py
@@ -16,7 +16,7 @@ from app.core.util import (
     get_time_until_timestamp,
 )
 
-RATE_LIMIT_ROUTE_REGEX = re.compile(r"^\/v1\/blocks|characters|planes")
+RATE_LIMIT_ROUTE_REGEX = re.compile(r"^\/v1\/blocks|characters|codepoints|planes")
 
 
 @dataclass


### PR DESCRIPTION
This pull request fixes an issue with the RATE_LIMIT_ROUTE_REGEX regular expression in the code. The regular expression was not including the 'codepoints' route, causing it to be excluded from rate limiting. This PR updates the regular expression to include the 'codepoints' route, ensuring that it is properly included in rate limiting.