### PR TITLE
Improve logging for same site requests

### DIFF
--- a/app/core/util.py
+++ b/app/core/util.py
@@ -77,3 +77,16 @@ def get_time_until_timestamp(ts: float) -> timedelta:
 
 def get_duration_between_timestamps(ts1: float, ts2: float) -> timedelta:
     return dtaware_fromtimestamp(ts2) - dtaware_fromtimestamp(ts1)
+
+
+def get_dict_report(data: dict, title: str | None = None) -> list[str]:
+    def dots(key: str, max_len: int) -> str:
+        return "." * ((max_len - len(key)) + 2)
+
+    report = []
+    if title:
+        report.append([f"{'#' * 5} {title} {'#' * 5}"])
+    max_key_len = max(len(str(key)) for key in data)
+    for key, value in data.items():
+        report.append(f"{key}{dots(str(key), max_key_len)}: {value}")
+    return report


### PR DESCRIPTION
This pull request improves the logging for same site requests. It adds a new function `get_dict_report` that generates a report of a dictionary's key-value pairs. This function is used to log the headers of same site requests when bypassing rate limiting. Additionally, the `rate_limit_applies_to_route` and `client_ip_is_external` functions have been moved to the `RateLimiter` class and renamed to `self.rate_limit_applies_to_route` and `self.client_ip_is_external` respectively. This improves code organization and encapsulation.