### PR TITLE
Correct default value for UMAMI_WEBSITE_ID in docker-bake.hcl

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -11,7 +11,7 @@ variable "UNICODE_VERSION" {
 }
 
 variable "UMAMI_WEBSITE_ID" {
-  default = "
+  default = ""
 }
 
 target "unicode-api" {


### PR DESCRIPTION
Update the default value for the UMAMI_WEBSITE_ID variable to an empty string.